### PR TITLE
make methods of Request class overridable

### DIFF
--- a/src/HTTP/Request.php
+++ b/src/HTTP/Request.php
@@ -19,10 +19,10 @@ class Request implements \Billingo\API\Connector\Contracts\Request
 	/**
 	 * @var Client
 	 */
-	private $client;
+	protected $client;
 
 
-	private $config;
+	protected $config;
 
 	/**
 	 * Request constructor.


### PR DESCRIPTION
A Request-t osztályt származtattam és felülírtam volna a request metódust. De mivel direktben hívja a `client` property-t (ami `private`) ezért nem lehet származtatni úgy hogy felülírhatóak legyenek a metódusok.

Ezért le kellett duplikálnom az egész osztályt és felülírni a request metódust. Ami nem szerencsés, ha frissülne ez a package.

Erre megoldás ez a PR.

Amúgy a hibaüzeneteket a `request` metódus nem adja vissza, hanem Exception-t dob. Ezt egy saját Request osztályban lekezeltem, hogy tömbként adja vissza a hibaüzeneteket, így rá lehet tenni egy űrlapra és nem kell leimplementálni a validációs szabályokat minden api model-re.

Erre nem csinálok PR-t, mert nem lenne visszafele kompatibilis.